### PR TITLE
Fix Mu Character.

### DIFF
--- a/test/test_ome.py
+++ b/test/test_ome.py
@@ -11,14 +11,14 @@ ElementTree.register_namespace('', 'http://www.openmicroscopy.org/Schemas/OME/20
 @pytest.fixture
 def expected_ome_xml_str_py38():
     return """<?xml version='1.0' encoding='ascii'?>
-<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06 http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd"><Image ID="Image:0" Name="image.tiff"><Pixels ID="Pixels:0" Type="double" SizeX="200" SizeY="200" SizeC="10" SizeZ="1" SizeT="1" DimensionOrder="XYCZT" Interleaved="false" BigEndian="false"><Channel ID="Channel:0:0" SamplesPerPixel="1" Name="Channel 1" /><Channel ID="Channel:0:1" SamplesPerPixel="1" Name="Channel 2" /><Channel ID="Channel:0:2" SamplesPerPixel="1" Name="Channel 3" /><Channel ID="Channel:0:3" SamplesPerPixel="1" Name="Channel 4" /><Channel ID="Channel:0:4" SamplesPerPixel="1" Name="Channel 5" /><Channel ID="Channel:0:5" SamplesPerPixel="1" Name="Channel 6" /><Channel ID="Channel:0:6" SamplesPerPixel="1" Name="Channel 7" /><Channel ID="Channel:0:7" SamplesPerPixel="1" Name="Channel 8" /><Channel ID="Channel:0:8" SamplesPerPixel="1" Name="Channel 9" /><Channel ID="Channel:0:9" SamplesPerPixel="1" Name="Channel 10" /><TiffData /></Pixels></Image></OME>"""
+<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06 http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd"><Image ID="Image:0" Name="image.tiff"><Pixels ID="Pixels:0" Type="double" SizeX="200" SizeY="200" SizeC="10" SizeZ="1" SizeT="1" DimensionOrder="XYCZT" Interleaved="false" BigEndian="false" PhysicalSizeX="1" PhysicalSizeXUnit="μm" PhysicalSizeY="1" PhysicalSizeYUnit="μm" PhysicalSizeZ="2" PhysicalSizeZUnit="μm"><Channel ID="Channel:0:0" SamplesPerPixel="1" Name="Channel 1" /><Channel ID="Channel:0:1" SamplesPerPixel="1" Name="Channel 2" /><Channel ID="Channel:0:2" SamplesPerPixel="1" Name="Channel 3" /><Channel ID="Channel:0:3" SamplesPerPixel="1" Name="Channel 4" /><Channel ID="Channel:0:4" SamplesPerPixel="1" Name="Channel 5" /><Channel ID="Channel:0:5" SamplesPerPixel="1" Name="Channel 6" /><Channel ID="Channel:0:6" SamplesPerPixel="1" Name="Channel 7" /><Channel ID="Channel:0:7" SamplesPerPixel="1" Name="Channel 8" /><Channel ID="Channel:0:8" SamplesPerPixel="1" Name="Channel 9" /><Channel ID="Channel:0:9" SamplesPerPixel="1" Name="Channel 10" /><TiffData /></Pixels></Image></OME>"""
 
 
 def test_get_ome_xml(expected_ome_xml_str_py38):
     num_channels = 10
     img = np.zeros((1, 1, num_channels, 200, 200, 1))
     channel_names = [f'Channel {i + 1}' for i in range(num_channels)]
-    ome_xml = get_ome_xml(img, 'image.tiff', channel_names, False, None, None)
+    ome_xml = get_ome_xml(img, 'image.tiff', channel_names, False, 1, 2)
     with BytesIO() as description_buffer:
         ome_xml.write(description_buffer, encoding='ascii', xml_declaration=True)
         description = description_buffer.getvalue().decode('ascii')

--- a/xtiff/ome.py
+++ b/xtiff/ome.py
@@ -53,14 +53,15 @@ def get_ome_xml(img: np.ndarray, image_name: Optional[str], channel_names: Optio
         'Interleaved': 'true' if interleaved else 'false',
         'BigEndian': 'true' if big_endian else 'false',
     })
+    mu = '\u03BC'
     if pixel_size is not None:
         pixels_element.set('PhysicalSizeX', str(pixel_size))
-        pixels_element.set('PhysicalSizeXUnit', 'µm')
+        pixels_element.set('PhysicalSizeXUnit', f'{mu}m')
         pixels_element.set('PhysicalSizeY', str(pixel_size))
-        pixels_element.set('PhysicalSizeYUnit', 'µm')
+        pixels_element.set('PhysicalSizeYUnit', f'{mu}m')
     if pixel_depth is not None:
         pixels_element.set('PhysicalSizeZ', str(pixel_depth))
-        pixels_element.set('PhysicalSizeZUnit', 'µm')
+        pixels_element.set('PhysicalSizeZUnit', f'{mu}m')
     for channel_id in range(size_c):
         channel_element = ElementTree.SubElement(pixels_element, 'Channel', attrib={
             'ID': 'Channel:0:{:d}'.format(channel_id),


### PR DESCRIPTION
The mu character appeared to somewhat non-functioning previously.  I'm not 100% sure what is going on here but the character now prints as &#956; instead of &#181; which seems more correct.  @LauraKuett could you test this out to confirm?