### PR TITLE
Fix for deprecated TiffWriter.save method.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: test-and-deploy
+name: test
 on:
   push:
     branches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,28 +40,3 @@ jobs:
           pytest --cov=./
       - name: Coverage
         uses: codecov/codecov-action@v1
-  deploy:
-    name: Deploy
-    needs:
-      - test
-    runs-on: ubuntu-latest
-    if: contains(github.ref, 'tags')
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Python 3
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.x
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade setuptools setuptools_scm wheel twine
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TWINE_API_KEY }}
-        run: |
-          git tag
-          python setup.py sdist bdist_wheel
-          twine upload dist/*

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -1,0 +1,67 @@
+name: test-and-deploy
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+jobs:
+  test:
+    name: Test ${{ matrix.platform }} py${{ matrix.python-version }}
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      matrix:
+        platform:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+        python-version:
+          - 3.7
+          - 3.8
+          - 3.9
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade -r test/requirements.txt
+          pip install --upgrade ".[all]"
+      - name: Test with pytest
+        run: |
+          pytest --cov=./
+      - name: Coverage
+        uses: codecov/codecov-action@v1
+  deploy:
+    name: Deploy
+    needs:
+      - test
+    runs-on: ubuntu-latest
+    if: contains(github.ref, 'tags')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python 3
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade setuptools setuptools_scm wheel twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TWINE_API_KEY }}
+        run: |
+          git tag
+          python setup.py sdist bdist_wheel
+          twine upload dist/*

--- a/xtiff/tiff.py
+++ b/xtiff/tiff.py
@@ -254,7 +254,7 @@ def to_tiff(img, file, image_name: Union[str, bool, None] = None, image_date: Un
     metadata = None if profile == TiffProfile.OME_TIFF else {}
     with TiffWriter(file, bigtiff=big_tiff, byteorder=byte_order, imagej=imagej) as writer:
         # set photometric to 'MINISBLACK' to not treat three-channel images as RGB
-        writer.save(data=img, photometric='MINISBLACK', compress=compression, description=description,
+        writer.write(data=img, photometric='MINISBLACK', compression=compression, description=description,
                     datetime=image_date, resolution=resolution, software=software, metadata=metadata)
 
 


### PR DESCRIPTION
TiffWriter.save is deprecated - we should replace replace with TiffWriter.write.
Issue: https://github.com/BodenmillerGroup/xtiff/issues/11

I also added a separate test.yml workflow to make development easier when not intending to deploy.



Changelog from tifffile

2022.2.2
    Fix TypeError when second ImageDescription tag contains non-ASCII (#112). Fix parsing IJMetadata with many IJMetadataByteCounts (#111). Detect MicroManager NDTiffv2 header (not tested). Remove cache from ZarrFileSequenceStore (use zarr.LRUStoreCache). Raise limit on maximum number of pages. Use J2K format when encoding JPEG2000 segments. Formally deprecate imsave and TiffWriter.save. Drop support for Python 3.7 and numpy < 1.19 (NEP29).

